### PR TITLE
Add support for describing the Event Dispatcher component

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 vendor/
+framework/
 composer.lock
 phpunit.xml

--- a/composer.json
+++ b/composer.json
@@ -19,8 +19,8 @@
         "php": ">=5.4"
     },
     "require-dev": {
-        "symfony/console": "^2.7",
-        "symfony/routing": "^2.7"
+        "symfony/console": "^3.3",
+        "symfony/routing": "^3.3"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,8 @@
     },
     "require-dev": {
         "symfony/console": "^3.3",
-        "symfony/routing": "^3.3"
+        "symfony/routing": "^3.3",
+        "symfony/event-dispatcher": "^3.3"
     },
     "autoload": {
         "psr-4": {

--- a/src/Descriptor/Descriptor.php
+++ b/src/Descriptor/Descriptor.php
@@ -5,6 +5,7 @@ namespace Codito\Silex\Console\Descriptor;
 use Symfony\Component\Console\Descriptor\DescriptorInterface;
 use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\Routing\Route;
 use Symfony\Component\Routing\RouteCollection;
 
@@ -35,6 +36,12 @@ abstract class Descriptor implements DescriptorInterface
                 break;
             case $object instanceof Route:
                 $this->describeRoute($object, $options);
+                break;
+            case $object instanceof EventDispatcherInterface:
+                $this->describeEventDispatcherListeners($object, $options);
+                break;
+            case is_callable($object):
+                $this->describeCallable($object, $options);
                 break;
             default:
                 throw new \InvalidArgumentException(sprintf('Object of type "%s" is not describable.', get_class($object)));
@@ -94,6 +101,25 @@ abstract class Descriptor implements DescriptorInterface
      * @param array $options
      */
     abstract protected function describeRoute(Route $route, array $options = array());
+
+    /**
+     * Describes event dispatcher listeners.
+     *
+     * Common options are:
+     * * name: name of listened event
+     *
+     * @param EventDispatcherInterface $eventDispatcher
+     * @param array                    $options
+     */
+    abstract protected function describeEventDispatcherListeners(EventDispatcherInterface $eventDispatcher, array $options = array());
+
+    /**
+     * Describes a callable.
+     *
+     * @param callable $callable
+     * @param array    $options
+     */
+    abstract protected function describeCallable($callable, array $options = array());
 
     /**
      * Formats a value as string.

--- a/src/Descriptor/TextDescriptor.php
+++ b/src/Descriptor/TextDescriptor.php
@@ -21,11 +21,13 @@ class TextDescriptor extends Descriptor
     protected function describeRouteCollection(RouteCollection $routes, array $options = array())
     {
         $showControllers = isset($options['show_controllers']) && $options['show_controllers'];
-        $headers = array('Name', 'Method', 'Scheme', 'Host', 'Path');
-        $table = new Table($this->getOutput());
-        $table->setStyle('compact');
-        $table->setHeaders($showControllers ? array_merge($headers, array('Controller')) : $headers);
 
+        $tableHeaders = array('Name', 'Method', 'Scheme', 'Host', 'Path');
+        if ($showControllers) {
+            $tableHeaders[] = 'Controller';
+        }
+
+        $tableRows = array();
         foreach ($routes->all() as $name => $route) {
             $row = array(
                 $name,
@@ -45,11 +47,16 @@ class TextDescriptor extends Descriptor
                 $row[] = $controller;
             }
 
-            $table->addRow($row);
+            $tableRows[] = $row;
         }
 
-        $this->writeText($this->formatSection('router', 'Current routes')."\n", $options);
-        $this->renderTable($table, !(isset($options['raw_output']) && $options['raw_output']));
+        if (isset($options['output'])) {
+            $options['output']->table($tableHeaders, $tableRows);
+        } else {
+            $table = new Table($this->getOutput());
+            $table->setHeaders($tableHeaders)->setRows($tableRows);
+            $table->render();
+        }
     }
 
     /**
@@ -57,49 +64,48 @@ class TextDescriptor extends Descriptor
      */
     protected function describeRoute(Route $route, array $options = array())
     {
-        $requirements = $route->getRequirements();
-        unset($requirements['_scheme'], $requirements['_method']);
-
-        // fixme: values were originally written as raw
-        $description = array(
-            '<comment>Path</comment>         '.$route->getPath(),
-            '<comment>Path Regex</comment>   '.$route->compile()->getRegex(),
-            '<comment>Host</comment>         '.('' !== $route->getHost() ? $route->getHost() : 'ANY'),
-            '<comment>Host Regex</comment>   '.('' !== $route->getHost() ? $route->compile()->getHostRegex() : ''),
-            '<comment>Scheme</comment>       '.($route->getSchemes() ? implode('|', $route->getSchemes()) : 'ANY'),
-            '<comment>Method</comment>       '.($route->getMethods() ? implode('|', $route->getMethods()) : 'ANY'),
-            '<comment>Class</comment>        '.get_class($route),
-            '<comment>Defaults</comment>     '.$this->formatRouterConfig($route->getDefaults()),
-            '<comment>Requirements</comment> '.($requirements ? $this->formatRouterConfig($requirements) : 'NO CUSTOM'),
-            '<comment>Options</comment>      '.$this->formatRouterConfig($route->getOptions()),
+        $tableHeaders = array('Property', 'Value');
+        $tableRows = array(
+            array('Route Name', isset($options['name']) ? $options['name'] : ''),
+            array('Path', $route->getPath()),
+            array('Path Regex', $route->compile()->getRegex()),
+            array('Host', ('' !== $route->getHost() ? $route->getHost() : 'ANY')),
+            array('Host Regex', ('' !== $route->getHost() ? $route->compile()->getHostRegex() : '')),
+            array('Scheme', ($route->getSchemes() ? implode('|', $route->getSchemes()) : 'ANY')),
+            array('Method', ($route->getMethods() ? implode('|', $route->getMethods()) : 'ANY')),
+            array('Requirements', ($route->getRequirements() ? $this->formatRouterConfig($route->getRequirements()) : 'NO CUSTOM')),
+            array('Class', get_class($route)),
+            array('Defaults', $this->formatRouterConfig($route->getDefaults())),
+            array('Options', $this->formatRouterConfig($route->getOptions())),
         );
-
-        if (isset($options['name'])) {
-            array_unshift($description, '<comment>Name</comment>         '.$options['name']);
-            array_unshift($description, $this->formatSection('router', sprintf('Route "%s"', $options['name'])));
+        if (isset($options['callable'])) {
+            $tableRows[] = array('Callable', $options['callable']);
         }
 
-        $this->writeText(implode("\n", $description)."\n", $options);
+        $table = new Table($this->getOutput());
+        $table->setHeaders($tableHeaders)->setRows($tableRows);
+        $table->render();
     }
 
     /**
-     * @param array $array
+     * @param array $config
      *
      * @return string
      */
-    private function formatRouterConfig(array $array)
+    private function formatRouterConfig(array $config)
     {
-        if (!count($array)) {
+        if (empty($config)) {
             return 'NONE';
         }
 
-        $string = '';
-        ksort($array);
-        foreach ($array as $name => $value) {
-            $string .= ($string ? "\n".str_repeat(' ', 13) : '').$name.': '.$this->formatValue($value);
+        ksort($config);
+
+        $configAsString = '';
+        foreach ($config as $key => $value) {
+            $configAsString .= sprintf("\n%s: %s", $key, $this->formatValue($value));
         }
 
-        return $string;
+        return trim($configAsString);
     }
 
     /**


### PR DESCRIPTION
Builds on #1 (so that should be merged first, or just let me know if you want me to rebase upon the 2.7 version)

Adds support for describing the event dispatcher. Tested by running a Silex-specific version of the [EventDispatcherDebugCommand](https://github.com/symfony/symfony/blob/master/src/Symfony/Bundle/FrameworkBundle/Command/EventDispatcherDebugCommand.php)